### PR TITLE
[ci skip] [skip ci] Minor build dependency updates

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -21,8 +21,8 @@ requirements:
   host:
     - python ${{ python_min }}.*
     - pip
-    - setuptools >=40.6.0
-    - setuptools_scm >=6.2
+    - setuptools >=66.1.0
+    - setuptools-scm >=8.1.0
   run:
     - ibm-platform-services >=0.61.1
     - numpy >=1.26.2


### PR DESCRIPTION
Not bumping the build number because only the bounds on the build dependencies were changed. The motivation for this change is to reduce the dependency diff in future bot updates.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
